### PR TITLE
Support for non-forced basename slugs and translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@ Page Hierarchy
 *Author: Ahmad Khayyat (<akhayyat@gmail.com>)*
 
 A [Pelican][1] plugin that creates a URL hierarchy for pages that
-matches the filesystem hierarchy of their sources. For example, the
-following filesystem structure for page sources will result in the
-URLs listed next to each page when this plugin is used with the
-default pelican settings.
+matches the filesystem hierarchy of their sources.
+
+For example, the following filesystem structure for page sources will
+result in the URLs listed next to each page when this plugin is used and
+`PAGE_URL = 'pages/{slug}/'` and  `PAGE_SAVE_AS = 'pages/{slug}/index.html'`
+are set.
 
 ```text
 └── content/pages/           #   PAGE_DIR
@@ -19,29 +21,19 @@ default pelican settings.
     │       └── features.md  # URL: pages/projects/p2/features/
     └── contact.md           # URL: pages/contact/
 ```
+When generating the `url` and `save_as` values, the plugin attaches
+relative path prefix to page's `slug` property (which can be
+auto-slugified from `title`, `basename`, `PATH_METADATA`, or set manually).
 
-To remove the `pages/` prefix and have pages at the root of your site:
-
-```python
-# pelicanconf.py
-PATH_METADATA = 'pages/(?P<path>.*)\..*'
-```
-
-More generally, any value for the `PATH_METADATA` pelican setting that
-defines a `path` group will result in using the matching part of the
-source file path as the path for that page in the URL. This allows
-capturing other metadata from the source path.
-
-In order to maintain a URL hierarchy that is consistent with the
-filesystem hierarchy, the slug of each page is forced to be its source
-base filename. The page title and its slug attribute have no effect.
+The plugin is aware and works well with translations.
 
 Parent and Children Pages
 -------------------------
 This plugin also adds three attributes to each page object:
 
 - `parent`: the immediate parent page. `None` if the page is
-  top-level.
+  top-level. If a translated page has no parent, the default-language
+  parent is used.
 
 - `parents`: a list of all ancestor pages, starting from the top-level
   ancestor.

--- a/page_hierarchy.py
+++ b/page_hierarchy.py
@@ -1,56 +1,78 @@
 from pelican import signals, contents
-from os.path import splitext, dirname
+import os.path
+from copy import copy
+from itertools import chain
 
 '''
 This plugin creates a URL hierarchy for pages that matches the
-filesystem hierarchy of their sources.
-
-To maintain a URL hierarchy that is consistent with the filesystem
-hierarchy, the slug of each page is forced to be the path of its source
-file.
+directory hierarchy of their sources.
 '''
 
+class UnexpectedException(Exception): pass
+
 def get_path(page, settings):
-    '''
-    if a 'path' is defined in PATH_METADATA, extract it. otherwise,
-    use the entire path after removing PAGE_DIR and the file
-    extension.
-    '''
-    if '<path>' in settings['PATH_METADATA']:
-        return page.path
-    else:
-        return splitext(page.get_relative_source_path())[0]
+    ''' Return the dirname relative to PAGE_PATHS prefix. '''
+    path = os.path.split(page.get_relative_source_path())[0] + '/'
+    # Try to lstrip the longest prefix first
+    for prefix in sorted(settings['PAGE_PATHS'], key=len, reverse=True):
+        if not prefix.endswith('/'): prefix += '/'
+        if path.startswith(prefix):
+            return path[len(prefix):-1]
+    raise UnexpectedException('Page outside of PAGE_PATHS ?!?')
+
+def in_default_lang(page):
+    # page.in_default_lang property is undocumented (=unstable) interface
+    return page.lang == page.settings['DEFAULT_LANG']
 
 def override_metadata(content_object):
-    if type(content_object) is contents.Page:
-        page = content_object
+    if type(content_object) is not contents.Page:
+        return
+    page = content_object
+    path = get_path(page, page.settings)
 
-        # set url, slug, and save_as attributes
-        path = get_path(page, page.settings)
-        if not hasattr(page, 'override_url'):
-            page.override_url = '%s/' % path
-            page.slug = '%s' % path
-        if not hasattr(page, 'override_save_as'):
-            page.override_save_as = '%s/index.html' % path
+    def _override_value(page, key):
+        metadata = copy(page.metadata)
+        # We override the slug to include the path up to the filename
+        metadata['slug'] = os.path.join(path, page.slug)
+        # We have to account for non-default language and format either,
+        # e.g., PAGE_SAVE_AS or PAGE_LANG_SAVE_AS
+        infix = '' if in_default_lang(page) else 'LANG_'
+        return page.settings['PAGE_' + infix + key.upper()].format(**metadata)
+
+    for key in ('save_as', 'url'):
+        if not hasattr(page, 'override_' + key):
+            setattr(page, 'override_' + key, _override_value(page, key))
 
 def set_relationships(generator):
+    def _all_pages():
+        return chain(generator.pages, generator.translations)
+
     # initialize parents and children lists
-    for page in generator.pages:
+    for page in _all_pages():
         page.parent = None
         page.parents = []
         page.children = []
 
     # set immediate parents and children
-    for page in generator.pages:
-        parent_url = dirname(dirname(page.url))
+    for page in _all_pages():
+        # Parent of /a/b/ is /a/, parent of /a/b.html is /a/
+        parent_url = os.path.dirname(page.url[:-1])
         if parent_url: parent_url += '/'
-        for page2 in generator.pages:
+        for page2 in _all_pages():
             if page2.url == parent_url and page2 != page:
                 page.parent = page2
                 page2.children.append(page)
+        # If no parent found, try the parent of the default language page
+        if not page.parent and not in_default_lang(page):
+            for page2 in generator.pages:
+                if (page.slug == page2.slug and
+                    os.path.dirname(page.source_path) ==
+                    os.path.dirname(page2.source_path)):
+                    # Only set the parent but not the children, obviously
+                    page.parent = page2.parent
 
     # set all parents (ancestors)
-    for page in generator.pages:
+    for page in _all_pages():
         p = page
         while p.parent:
             page.parents.insert(0, p.parent)


### PR DESCRIPTION
The URL and SAVE_AS overrides are now generated from
PAGE_URL and PAGE_SAVE_AS (and PAGE_LANG_URL and PAGE_LANG_SAVE_AS).
To rid of 'pages/' prefix, PATH_METADATA is no longer needed if
PAGE_URL is set to exclude it. Also slugs can be slugified from
the title or basename or set in the header. Translations should
also work all as expected.

When there is no parent for a translated page, the parent of the
non-translated equivalent is used.

Also closes #1. What do you think?
