### PR TITLE
Serve index pages from parent/index.html

### DIFF
--- a/page_hierarchy.py
+++ b/page_hierarchy.py
@@ -32,8 +32,12 @@ def override_metadata(content_object):
 
     def _override_value(page, key):
         metadata = copy(page.metadata)
-        # We override the slug to include the path up to the filename
-        metadata['slug'] = os.path.join(path, page.slug)
+        # We override the slug to include the path up to the filename. Index
+        # pages for index pages, 
+        if page.slug == "index":
+            metadata['slug'] = path
+        else:
+            metadata['slug'] = os.path.join(path, page.slug)
         # We have to account for non-default language and format either,
         # e.g., PAGE_SAVE_AS or PAGE_LANG_SAVE_AS
         infix = '' if in_default_lang(page) else 'LANG_'


### PR DESCRIPTION
Today the index pages are served from a dedicated "index" directory (`parent/index/index.html`). This is redundant and non-standard. This PR allows them to be served through `parent/index.html` instead.